### PR TITLE
feat: generate invoices via serverless API

### DIFF
--- a/app/invoice/page.tsx
+++ b/app/invoice/page.tsx
@@ -48,13 +48,16 @@ export default function InvoicePage() {
     e.preventDefault();
     setMessage('Формується рахунок...');
     try {
-      const res = await fetch('https://script.google.com/macros/s/AKfycbybysv8cx9j8-X1QazC2VyOnXdWbCySS6q4IN9gXd6lJ5dDfv1mbgJnq8Ou8ztHSEDI0w/exec', {
+      const res = await fetch('/api/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
-      const result = await res.json();
-      setMessage(`✅ Рахунок сформовано. <a href="${result.url}" target="_blank" class="text-blue-600 underline">Переглянути PDF</a>`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      setMessage(
+        `✅ Рахунок сформовано. <a href="${url}" target="_blank" download="invoice.pdf" class="text-blue-600 underline">Завантажити PDF</a>`
+      );
     } catch (err) {
       console.error(err);
       setMessage('❌ Помилка під час створення рахунку.');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.2.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@react-pdf/renderer": "^3.1.8"
   },
   "devDependencies": {
     "@types/node": "20.11.30",

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Document, Page, Text, View, StyleSheet, pdf } from '@react-pdf/renderer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const data = req.body;
+
+  const styles = StyleSheet.create({
+    section: { margin: 10, padding: 10, fontSize: 12 },
+  });
+
+  const doc = (
+    <Document>
+      <Page>
+        <View style={styles.section}>
+          <Text>Invoice Number: {data.invoiceNumber}</Text>
+          <Text>Date: {data.date}</Text>
+          <Text>Client: {data.clientName}</Text>
+          <Text>Service: {data.service}</Text>
+          <Text>
+            Quantity: {data.quantity} {data.unit}
+          </Text>
+          <Text>Price: {data.price}</Text>
+          <Text>Total: {data.total}</Text>
+        </View>
+      </Page>
+    </Document>
+  );
+
+  const pdfBuffer = await pdf(doc).toBuffer();
+
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', 'attachment; filename="invoice.pdf"');
+  res.send(Buffer.from(pdfBuffer));
+}


### PR DESCRIPTION
## Summary
- remove external Google Script call and request local API for PDFs
- implement API route generating PDF using `@react-pdf/renderer`
- add dependency for PDF generation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found; dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68badb5615e4832385f72ca251d05e96